### PR TITLE
fix(ci)：PR 的那一輪不該排進 gh-pages 的寫入佇列

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,25 @@ on:
 permissions:
   contents: write # 推 gh-pages 分支的 preview/
 
+# 這個 group 的用途是**序列化 gh-pages 的寫入**：deploy.yml（寫根目錄）與本檔的
+# dev push（寫 preview/）寫的是同一個分支的不同子目錄，共用一個 group 才不會互相覆蓋。
+#
+# 但 PR 的那一輪**不寫 gh-pages**（下方部署步驟的 if 已經排除它）。
+# 把不寫入的 run 放進寫入者的佇列，會踩到 GitHub 的一條行為：
+# 同一個 group 只保留一個 pending run，新的排進來就把舊的取消掉。
+#
+# 實際發生過（合併 main、推 dev、開 PR 擠在一分鐘內）：
+#
+#   08:53 deploy.yml(main) 開始 ── 佔住 group
+#   08:54 ci.yml(push dev)  排隊
+#   08:55 ci.yml(PR)        排隊 ── 把排隊中的 push 那輪取消掉
+#
+# push 那輪是唯一會部署預覽站的，於是預覽站安靜地停在上一版：
+# 沒有失敗、沒有紅燈，只是維護者在手機上看到的還是舊的。
+#
+# 所以 PR 用自己的 group——它不寫 gh-pages，本來就不該排在寫入佇列裡。
 concurrency:
-  group: gh-pages-write
+  group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.ref) || 'gh-pages-write' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## 症狀

推 `dev` 之後預覽站沒有更新，但**沒有任何失敗、沒有紅燈**。CI 全綠、PR 全綠，只有維護者在手機上看到的是舊的。

## 實際時序

合併 `main`、推 `dev`、開 PR 擠在一分鐘內時：

```
08:53:48  deploy.yml(main 45cc104) 開始 ── 佔住 group 直到 08:55:27
08:54:18  ci.yml push(dev 765951b)  排隊等 group
08:55:18  ci.yml pull_request        排隊 ── 把排隊中的 push 那輪取消掉
08:55:27  deploy 結束，PR 那輪跑起來、成功
```

被取消的 push 那輪是**唯一會部署預覽站的**（部署步驟的 `if` 是 `github.event_name == 'push'`），於是預覽站安靜地停在上一版。

實際的 run：[push 那輪被 cancelled](https://github.com/kielchang/dooping-design-book/actions/runs/30437390928)、[PR 那輪 success](https://github.com/kielchang/dooping-design-book/actions/runs/30437462263)。

## 根因不是 concurrency group 本身

共用 group 是**對的**——`deploy.yml` 寫 gh-pages 根目錄、`ci.yml` 的 dev push 寫 `preview/`，同一個分支的不同子目錄，不共用會互相覆蓋。（這件事本身已經寫在〈漂移防護〉的第 8 支守衛裡。）

根因是**把不寫 gh-pages 的 run 也放進了寫入者的佇列**。GitHub 對同一個 group 只保留一個 pending run，新的排進來就取消舊的——而 PR 那一輪根本不寫任何東西。

## 改法

```yaml
group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.ref) || 'gh-pages-write' }}
```

PR 用自己的 group，寫入者維持 `gh-pages-write`。

**部署步驟的 `if` 一個字都沒動**——什麼時候部署預覽站的規則完全不變，預覽站仍然只有 dev push 會寫，PR 不會覆蓋它。

## 為什麼不用另外兩種改法

| 方案 | 不採用的理由 |
|---|---|
| 放寬部署條件，讓 PR 也部署預覽 | 會讓 PR 覆蓋 dev 的預覽站，而預覽站的定位是「dev 的當下狀態」。而且 PR 事件的 `github.sha` 是 merge commit，部署訊息會指向一個不存在於任何分支的 SHA |
| 開 PR 前先等 push 那輪跑完 | 零程式碼變更，但靠紀律不靠機制——這本書自己的〈不要只靠 code review〉正是在講這種東西靠不住 |

## 驗證

- YAML 解析通過，`concurrency.group` 是預期的運算式，部署步驟的 `if` 維持 `github.event_name == 'push'`
- `npm test` 84 綠
- **這支 PR 自己就會走 `pull_request` 那條路**——它的 check run 跑起來就證明新的 group 運作正常；運算式若寫壞，workflow 會當場載入失敗

合併後下一次推 `dev` 就能確認 push 那輪不再被取消。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SajvtALoa8RnkrVtHSSFqs)_